### PR TITLE
feat: scaffold base layout with hash routing

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,500 @@
+# Kế hoạch chi tiết (Markdown) — App học tiếng Anh từ DailyDictation (MVP thủ công)
+
+> **Các quyết định đã chốt**
+> 1) **Nhập dữ liệu**: thủ công (Paste URL/transcript + link/Upload audio).  
+> 2) **Chấm điểm Speaking/Writing**: chấp nhận bản MVP (ASR + rule-based, không phụ thuộc LLM).  
+> 3) **Listening Cloze mặc định**: **2–3 từ** (có thể chọn 1 từ / cả câu / cả bài).
+
+---
+
+## 1) Kiến trúc tổng quan
+
+- **Web**: React 19 + Vite + TypeScript + Tailwind + **shadcn/ui** (Radix).  
+- **State**: TanStack Query (server state), Zustand/Context (UI pref).  
+- **Backend**: **Supabase** (Auth, Postgres, Storage, Edge Functions).  
+- **Audio**: phát trực tiếp từ URL/Storage; cache nhẹ (PWA).  
+- **Scoring**:  
+  - Listening: so khớp văn bản (tolerance lỗi chính tả/caps).  
+  - Speaking: **Web Speech API** → tokenization → similarity (WER / cosine TF-IDF).  
+  - Writing: **chunk-coverage check** + rule-based gợi ý “native-like” (không LLM ở MVP).
+- **SRS**: SM-2 rút gọn (due_at, interval, ease, reps, lapses).  
+- **Triển khai**: Vercel (web) + Supabase (DB/Functions).
+
+---
+
+## 2) Cấu trúc thư mục (Frontend)
+
+```
+src/
+  app/               # routes (react-router)
+    auth/
+    home/
+    library/
+    lesson/[id]/     # tabs: reading/listening/speaking/writing/review
+    review/
+    tests/
+    importer/
+    settings/
+  components/
+    lesson/
+    review/
+    ui/              # shadcn components wrapper
+  hooks/
+  lib/
+    supabase.ts
+    speech.ts       # Web Speech helpers
+    text.ts         # tokenization, similarity, cloze utils
+    srs.ts          # SM-2 helpers
+  store/
+  types/
+  styles/
+```
+
+---
+
+## 3) Lộ trình thực thi (Step-by-step)
+
+### M0 — Bootstrap dự án (0.5–1 ngày)
+- Tạo repo, **pnpm** workspace.  
+- Vite + React 19 + TS: `pnpm create vite` → react-ts.  
+- Tailwind + shadcn/ui: cài đặt, cấu hình theme, font.  
+- ESLint/Prettier/Husky + Vitest + Playwright.  
+- Tạo `supabase.ts` (client), `.env` mẫu.
+
+**Mục tiêu chấp nhận**  
+- App chạy được, có layout base, dark/light, bottom nav (mobile) + header (desktop).  
+
+---
+
+### M1 — Supabase & schema (1–1.5 ngày)
+
+#### 1.1 Bảng dữ liệu (SQL)
+```sql
+-- Nguồn (giữ URL gốc để tôn trọng bản quyền)
+create table public.sources (
+  id uuid primary key default gen_random_uuid(),
+  source_url text not null,
+  title text,
+  notes text,
+  created_at timestamptz default now()
+);
+
+-- Bài học (mỗi bài nghe)
+create table public.lessons (
+  id uuid primary key default gen_random_uuid(),
+  source_id uuid references public.sources(id) on delete set null,
+  title text not null,
+  transcript text not null,         -- toàn bài
+  audio_url text,                   -- có thể là storage/public url
+  meta jsonb default '{}'::jsonb,   -- tags: level/topic
+  created_by uuid references auth.users(id),
+  is_private boolean default true,  -- MVP: học cá nhân
+  created_at timestamptz default now()
+);
+
+-- Câu (tách từ transcript)
+create table public.sentences (
+  id uuid primary key default gen_random_uuid(),
+  lesson_id uuid references public.lessons(id) on delete cascade,
+  idx int not null,
+  text text not null,
+  start_sec numeric, -- optional thủ công
+  end_sec numeric
+);
+
+-- Chunk / collocation / phrase quan trọng
+create table public.chunks (
+  id uuid primary key default gen_random_uuid(),
+  lesson_id uuid references public.lessons(id) on delete cascade,
+  text text not null,
+  kind text check (kind in ('collocation','phrasal','pattern','idiom','useful')),
+  example text,
+  notes text
+);
+
+-- Bài tập sinh tự động theo lesson
+create table public.exercises (
+  id uuid primary key default gen_random_uuid(),
+  lesson_id uuid references public.lessons(id) on delete cascade,
+  kind text check (kind in ('reading_cloze','listening_cloze','speaking','writing')) not null,
+  payload jsonb not null,    -- schema xem phần Data Contracts
+  created_at timestamptz default now()
+);
+
+-- Tiến độ người dùng
+create table public.user_progress (
+  id bigserial primary key,
+  user_id uuid references auth.users(id) on delete cascade,
+  lesson_id uuid references public.lessons(id) on delete cascade,
+  status text check (status in ('not_started','in_progress','completed')) default 'in_progress',
+  score jsonb,          -- điểm chi tiết từng kỹ năng
+  updated_at timestamptz default now()
+);
+
+-- SRS: item là CHUNK đã chọn
+create table public.srs_items (
+  id bigserial primary key,
+  user_id uuid references auth.users(id) on delete cascade,
+  chunk_id uuid references public.chunks(id) on delete cascade,
+  due_at timestamptz not null,
+  interval_days int default 0,
+  ease float default 2.5,
+  reps int default 0,
+  lapses int default 0,
+  last_reviewed_at timestamptz
+);
+create index on public.srs_items (user_id, due_at);
+```
+
+#### 1.2 RLS (rút gọn)
+```sql
+alter table public.lessons enable row level security;
+create policy "own_or_private" on public.lessons
+for select using (is_private or (auth.uid() = created_by))
+with check (auth.uid() = created_by);
+
+alter table public.user_progress enable row level security;
+create policy "own_progress" on public.user_progress
+for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+
+alter table public.srs_items enable row level security;
+create policy "own_srs" on public.srs_items
+for all using (auth.uid() = user_id) with check (auth.uid() = user_id);
+```
+
+**Mục tiêu chấp nhận**  
+- Migration chạy OK.  
+- Bảng/Policy tạo xong; insert thử 1 record thành công.
+
+---
+
+### M2 — Edge Functions (2–3 ngày)
+
+#### 2.1 `import-from-manual`
+- Input: `{ source_url?, title?, transcript, audio_url? }`  
+- Bước: sanitize, save `sources/lessons`, **split sentences** (rule-based: `.?!` + viết tắt), bulk insert.  
+- Output: `lesson_id`.
+
+#### 2.2 `generate-exercises`
+- Input: `{ lesson_id, options: { listeningCloze: { default='2-3', blanksPerSentence='auto' }, readingCloze: { density='medium' } } }`
+- Tạo:
+  - **reading_cloze**: từ transcript → ẩn **content words** (noun/verb/adj/adv), tránh stopwords; density theo cài đặt.
+  - **listening_cloze**: mặc định **2–3 từ** (chọn cụm liền nhau), ưu tiên **chunks đã chọn** nếu có.
+  - **speaking**: lấy danh sách câu quan trọng (từ chunks hoặc manual pick).
+  - **writing**: tạo prompts tiếng Việt từ nội dung bài (rule-based templates).
+- Output: danh sách exercises → upsert `exercises`.
+
+#### 2.3 `submit-result`
+- Ghi điểm cho người dùng: `{ user_id, lesson_id, kind, result }` → cập nhật `user_progress.score`.
+
+#### 2.4 `srs-schedule`
+- Áp dụng **SM-2** đơn giản: quality 0–5 → cập nhật `interval_days, ease, reps, lapses, due_at`.
+
+**Mục tiêu chấp nhận**
+- Gọi được functions, sinh ra exercises hợp lệ cho 1 bài mẫu.
+
+---
+
+### M3 — Nhập liệu (UI Importer) (1–1.5 ngày)
+- Trang **/importer**:
+  1) Paste **URL**, **title**, **transcript**, **audio URL** hoặc **Upload**.  
+  2) Preview transcript → **Split sentences** (cho phép sửa tay).  
+  3) Lưu → tạo `lesson`.  
+- Hiển thị “**Legal note**”: chỉ dùng cho mục đích học cá nhân.
+
+**Mục tiêu chấp nhận**
+- Nhập thành công 1 bài, tách câu chuẩn, xem lại được ở /lesson/:id.
+
+---
+
+### M4 — Reading + Gợi ý chunks (2–3 ngày)
+
+#### 4.1 Viewer Reading
+- Transcript + **Glossary Panel** bên phải (desktop) / bottom sheet (mobile).  
+- Nút **“Gợi ý chunks”**.
+
+#### 4.2 Thuật toán gợi ý (MVP không LLM)
+- **Tokenize** + POS tagging nhẹ (regex/wordlist).  
+- Bóc tách:
+  - **Collocation patterns**: *verb+noun* (take a look), *adj+noun* (fast learner), *verb+prep* (depend on),  
+  - **Phrasal verbs**: look up, wind down, put off (wordlist).  
+  - **Useful patterns**: *be used to*, *make sure*, *as soon as*, *in case*.  
+- Tính **điểm ưu tiên**: tần suất, độ “có ích” (list cứng), độ dài, nằm trong câu “key”.  
+- UI cho phép **tick chọn** → tạo `chunks` + đề xuất **ví dụ** (trích câu thật).
+
+**Mục tiêu chấp nhận**
+- Chọn ít nhất 8–12 chunks cho 1 bài; thêm vào **SRS** thành công.
+
+---
+
+### M5 — Listening Cloze (2–3 ngày)
+
+#### 5.1 Generator
+- Default **2–3 từ** mỗi chỗ trống.  
+- Tránh ẩn **stopwords**, ưu tiên ẩn cụm **chunks**.  
+- Tuỳ chọn: 1 từ / cả câu / cả bài.
+
+#### 5.2 Player
+- Audio player (seek, tốc độ, loop đoạn).  
+- Ô điền trống với **tolerance**:
+  - Bỏ qua `case`, `punctuation`.  
+  - Cho phép lỗi nhỏ: Levenshtein ≤ 1–2 với từ ≤ 6 ký tự.  
+- Hints: chữ cái đầu, số ký tự, reveal 1/2 cụm.
+
+**Mục tiêu chấp nhận**
+- Làm đúng ≥ 80% testcases đơn giản; ghi điểm vào `user_progress`.
+
+---
+
+### M6 — Speaking (2 ngày)
+
+#### 6.1 Flow
+- Danh sách câu “quan trọng” → **Record** từng câu.  
+- **ASR**: Web Speech API (en-US) → transcript.  
+- So khớp:  
+  - Normalize: lowercase, bỏ punctuation, contractions mapping (I’m → I am).  
+  - **WER** (word error rate) & **coverage** chunk: highlight *missing/mispronounced* (dựa text).  
+- Phản hồi: badge “Great / Good / Try again”; cho phép **re-record**.
+
+**Mục tiêu chấp nhận**
+- Trải nghiệm ổn trên Chrome/Edge; graceful fallback khi browser không hỗ trợ.
+
+---
+
+### M7 — Writing (2 ngày)
+
+#### 7.1 Flow
+- App đưa **prompt tiếng Việt “đời thường”** từ bài → user trả lời **bằng tiếng Anh**.  
+- **Rule-based feedback**:
+  - Kiểm tra **coverage** của **chunks** (đã học) trong câu trả lời.  
+  - Mẫu lỗi cơ bản: thiếu `a/an`, `plural -s`, `preposition` thông dụng, `article` trước danh từ đếm được.  
+  - Gợi ý **native-like rewrite** bằng **patterns** đã lưu (ví dụ: *wind down*, *grab a coffee*, *make sure to*).  
+- **Hỏi lại bằng tiếng Anh**: user trả lời lại với câu đã sửa.
+
+**Mục tiêu chấp nhận**
+- UI hiển thị diff highlight; lưu lịch sử 2–3 lần sửa gần nhất.
+
+---
+
+### M8 — Ôn tập nhẹ cuối bài (1–1.5 ngày)
+- Random từ **chunks đã chọn**:  
+  - **Reading**: cloze chọn từ đúng (1 lựa chọn đúng + 3 distractors).  
+  - **Listening**: điền 1–3 từ từ audio cũ.  
+  - **Speaking**: đọc lại 1–2 câu.  
+  - **Writing**: hỏi lại 1 prompt EN, yêu cầu dùng ≥1 chunk.
+- **Đánh dấu xong bài** → cập nhật `user_progress.status='completed'`.
+
+**Mục tiêu chấp nhận**
+- Một vòng ôn tập hoàn chỉnh ≤ 5 phút.
+
+---
+
+### M9 — Kho bài & Mini/Big Test (1–2 ngày)
+- **/library**: filter theo tag/level; “Đã học”.  
+- **Chọn nhiều bài** → tạo **test**:
+  - Tập hợp **chunks** + **exercises** liên quan.  
+  - Thời lượng mini (≈10 phút) / big (≈25 phút).
+- Lưu **kết quả test** (tổng quan + kỹ năng).
+
+**Mục tiêu chấp nhận**
+- Tạo/chạy test ổn định, có summary điểm.
+
+---
+
+### M10 — Mobile polish, PWA & Analytics (1–1.5 ngày)
+- Bottom Nav, cỡ chữ, khoảng chạm lớn.  
+- PWA (offline shell + cache audio optional).  
+- Sự kiện analytics: `lesson_open`, `chunk_add`, `cloze_submit`, `speak_score`, `write_feedback`, `review_done`, `test_finish`.
+
+**Mục tiêu chấp nhận**
+- Lighthouse PWA pass cơ bản, TTI tốt trên mobile.
+
+---
+
+## 4) Data Contracts (Zod/TS)
+
+```ts
+// Cloze blank
+export type Blank = {
+  start: number; // index trong câu
+  end: number;
+  answer: string; // "wind down" hoặc 1-3 từ
+  hint?: { firstLetter?: boolean; length?: number };
+};
+
+export type ExerciseReadingCloze = {
+  type: 'reading_cloze';
+  sentenceId: string;
+  text: string;           // câu gốc
+  blanks: Blank[];
+  choices?: string[];     // distractors
+};
+
+export type ExerciseListeningCloze = {
+  type: 'listening_cloze';
+  sentenceId?: string;    // optional nếu theo đoạn/bài
+  scope: 'phrase' | 'sentence' | 'paragraph' | 'full';
+  blanks: Blank[];
+  audioUrl: string;
+  startSec?: number;
+  endSec?: number;
+};
+
+export type ExerciseSpeaking = {
+  type: 'speaking';
+  sentenceIds: string[];
+};
+
+export type ExerciseWriting = {
+  type: 'writing';
+  promptVi: string;
+  targetChunks: string[]; // yêu cầu sử dụng
+};
+```
+
+---
+
+## 5) Thuật toán & tiêu chí
+
+### 5.1 Chunk Suggestion
+- **Rule sets**:
+  - Phrasal verbs (wordlist ~500 mục).
+  - Collocations templates: `(verb + noun)`, `(adj + noun)`, `(verb + prep)`.
+  - Patterns hữu ích: *be used to, make sure (to), end up (V-ing), as soon as, in case*…
+- **Ưu tiên**: xuất hiện ≥2 lần, cụm 2–3 từ, có tính chuyển dụng cao trong đời sống.
+- **UX**: tick chọn → thêm vào SRS + gợi ý ví dụ.
+
+### 5.2 Listening Cloze
+- **Default 2–3 từ**: lấy cụm liền nhau; tránh dính punctuation; không chọn stopwords thuần.  
+- **Scoring**: normalize → token-level compare; cho Levenshtein ≤ 1–2/word (ngắn).
+
+### 5.3 Speaking
+- **ASR** → chuẩn hóa contractions, số nhiều, `to/be` rơi.  
+- **WER** + **chunk coverage** ≥ 70% → “Pass”; < 70% → “Try again” + highlight.
+
+### 5.4 Writing
+- **Checks**:  
+  - Has at least **1–2 target chunks**.  
+  - Lỗi cơ bản: article, plural, preposition hay gặp.  
+- **Feedback**: đưa **rewrite** theo pattern/chunk; hiển thị diff.
+
+### 5.5 SRS (SM-2 rút gọn)
+```
+if q < 3:
+  reps=0; interval=1; ease=max(1.3, ease-0.2)
+else:
+  reps+=1
+  if reps==1: interval=1
+  else if reps==2: interval=6
+  else: interval=round(interval*ease)
+  ease = ease + (0.1 - (5-q)*(0.08 + (5-q)*0.02))
+due_at = now + interval days
+```
+
+---
+
+## 6) Giao diện & thành phần (shadcn/ui)
+
+- **Shell**: Header, **BottomNav** (mobile), ThemeToggle.  
+- **Importer**: Textarea transcript, input URL, input audio, preview sentences.  
+- **Lesson View**:  
+  - Tabs: **Reading / Listening / Speaking / Writing / Review**  
+  - Reading: Transcript, **GlossaryPanel**, “Gợi ý chunks”, tick-to-SRS.  
+  - Listening: Player, Cloze form, Hints, Submit.  
+  - Speaking: Card từng câu, Record/Stop, Score.  
+  - Writing: Prompt (VI), Editor (EN), FeedbackDiff.  
+  - Review: 4 mini-drills xen kẽ.  
+- **Library**: LessonCard (đã học/chưa học), filter.  
+- **Tests**: Builder (select multiple lessons) → Test Runner.
+
+---
+
+## 7) Kiểm thử
+
+- **Unit**: tokenization, cloze generator, similarity, SM-2.  
+- **Component**: Reading viewer, Cloze, Record button.  
+- **E2E (Playwright)**:  
+  1) Import bài → Reading chọn 10 chunks → Listening cloze (2–3 từ) → Speaking 3 câu → Writing 1 prompt → Review → Mark completed.  
+  2) Chọn 3 bài → tạo Mini Test → làm xong → xem summary.
+
+---
+
+## 8) Bảo mật & pháp lý (MVP)
+
+- **is_private = true** cho mọi lesson import; lưu `source_url`.  
+- Không “xuất bản” transcript/audio ra public; chỉ dùng trong phiên học của tài khoản đó.  
+- Rate-limit `import-from-manual`; log hoạt động import.
+
+---
+
+## 9) DevOps & cấu hình
+
+- **ENV Frontend**:  
+  - `VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`.  
+- **ENV Functions** (server):  
+  - `SERVICE_ROLE_KEY` (chỉ chạy trên Edge Functions).  
+- **CI**: build, test; Vercel preview; Supabase migration automation.  
+- **PWA**: vite-plugin-pwa (cache manifest, offline shell; audio optional).
+
+---
+
+## 10) Timeline đề xuất (≈ 10–12 ngày công)
+
+- **M0**: Bootstrap — 0.5–1d  
+- **M1**: Schema + RLS — 1–1.5d  
+- **M2**: Edge functions — 2–3d  
+- **M3**: Importer UI — 1–1.5d  
+- **M4**: Reading + chunks — 2–3d  
+- **M5**: Listening — 2–3d  
+- **M6**: Speaking — 2d  
+- **M7**: Writing — 2d  
+- **M8**: Review + Test — 1–2d  
+- **M10**: Polish + Analytics — 1–1.5d  
+> (Một số hạng mục sẽ chạy song song; tổng thể ~2 tuần lịch.)
+
+---
+
+## 11) Tiêu chí hoàn thành (DoD) cho MVP
+
+- Nhập 1 bài từ DailyDictation **thủ công** → tạo được lesson + sentences.  
+- Chọn ≥ 8 chunks → thêm vào **SRS**.  
+- Listening Cloze **mặc định 2–3 từ** hoạt động ổn (tolerance chính tả nhẹ).  
+- Speaking chấm bằng **ASR** + WER; feedback realtime.  
+- Writing có **prompt VI → trả lời EN → sửa nhẹ → hỏi lại EN**.  
+- Ôn tập nhẹ cuối bài gồm đủ **4 kỹ năng**.  
+- Chọn nhiều bài → **Mini/Big Test** chạy được và lưu kết quả.  
+- Toàn bộ UI **responsive mobile-first**.
+
+---
+
+## 12) Rủi ro & hướng xử lý
+
+- **ASR không ổn định** → cung cấp transcript gợi ý + nút “I said it”.  
+- **Chia câu sai** → cho sửa tay trong Importer.  
+- **Khác biệt trình duyệt** Web Speech API → fallback: chỉ ghi âm & self-check (MVP).  
+- **Pháp lý** → chỉ học cá nhân; giữ `source_url`; không public; cân nhắc liên hệ chủ sở hữu nội dung nếu muốn phát hành rộng.
+
+---
+
+## 13) Hạng mục tương lai (ngoài MVP)
+
+- Forced alignment (tự động timecode per sentence).  
+- Scoring speaking nâng cao (server model).  
+- Grammar checker nâng cao (LanguageTool/LLM).  
+- Leaderboard, goals, streaks, badges.  
+- Subscription (Stripe) & chia sẻ bộ đề.
+
+---
+
+### Checklist trước khi bắt đầu coding
+- [ ] Tạo project Supabase + set env.  
+- [ ] Chạy migration schema & RLS.  
+- [ ] Tạo Edge Functions (stubs) và route key.  
+- [ ] Scaffold UI: Shell, Router, BottomNav.  
+- [ ] Trang Importer: paste transcript & preview.  
+- [ ] Lesson page + Reading tab + Chunk suggest.  
+- [ ] Listening Cloze (2–3 từ) + Player.  
+- [ ] Speaking (record + ASR + score).  
+- [ ] Writing (prompt VI → EN + feedback).  
+- [ ] Review cuối bài + Library + Test builder.  
+- [ ] Analytics & PWA cơ bản.

--- a/src/App.css
+++ b/src/App.css
@@ -1,42 +1,55 @@
 #root {
-  max-width: 1280px;
+  max-width: 600px;
   margin: 0 auto;
-  padding: 2rem;
-  text-align: center;
 }
 
-.logo {
-  height: 6em;
-  padding: 1.5em;
-  will-change: filter;
-  transition: filter 300ms;
-}
-.logo:hover {
-  filter: drop-shadow(0 0 2em #646cffaa);
-}
-.logo.react:hover {
-  filter: drop-shadow(0 0 2em #61dafbaa);
+.app {
+  min-height: 100vh;
+  padding-top: 56px;
+  padding-bottom: 56px;
 }
 
-@keyframes logo-spin {
-  from {
-    transform: rotate(0deg);
-  }
-  to {
-    transform: rotate(360deg);
-  }
+header {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 56px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 1rem;
+  background: var(--color-bg);
+  color: var(--color-fg);
+  border-bottom: 1px solid var(--color-border);
 }
 
-@media (prefers-reduced-motion: no-preference) {
-  a:nth-of-type(2) .logo {
-    animation: logo-spin infinite 20s linear;
-  }
+main {
+  padding: 1rem;
 }
 
-.card {
-  padding: 2em;
+.bottom-nav {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  height: 56px;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  background: var(--color-bg);
+  color: var(--color-fg);
+  border-top: 1px solid var(--color-border);
 }
 
-.read-the-docs {
-  color: #888;
+.bottom-nav button {
+  background: none;
+  border: none;
+  color: inherit;
+  font: inherit;
+  padding: 0;
+}
+
+.bottom-nav button.active {
+  font-weight: bold;
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,34 +1,73 @@
-import { useState } from 'react'
-import reactLogo from './assets/react.svg'
-import viteLogo from '/vite.svg'
+import { useEffect, useState } from 'react'
+import Home from './app/home'
+import Importer from './app/importer'
+import Settings from './app/settings'
+import Lesson from './app/lesson'
+
 import './App.css'
 
 function App() {
-  const [count, setCount] = useState(0)
+  const [route, setRoute] = useState(() => window.location.hash.slice(1) || 'home')
+  const [theme, setTheme] = useState<'dark' | 'light'>('dark')
+
+  useEffect(() => {
+    const onHashChange = () => setRoute(window.location.hash.slice(1) || 'home')
+    window.addEventListener('hashchange', onHashChange)
+    return () => window.removeEventListener('hashchange', onHashChange)
+  }, [])
+
+  useEffect(() => {
+    document.body.setAttribute('data-theme', theme)
+  }, [theme])
+
+  const navigate = (to: string) => {
+    window.location.hash = to
+  }
+
+  let page
+  if (route.startsWith('lesson/')) {
+    const id = route.split('/')[1]
+    page = <Lesson id={id} />
+  } else {
+    switch (route) {
+      case 'importer':
+        page = <Importer />
+        break
+      case 'settings':
+        page = <Settings />
+        break
+      default:
+        page = <Home />
+    }
+  }
 
   return (
-    <>
-      <div>
-        <a href="https://vite.dev" target="_blank">
-          <img src={viteLogo} className="logo" alt="Vite logo" />
-        </a>
-        <a href="https://react.dev" target="_blank">
-          <img src={reactLogo} className="logo react" alt="React logo" />
-        </a>
-      </div>
-      <h1>Vite + React</h1>
-      <div className="card">
-        <button onClick={() => setCount((count) => count + 1)}>
-          count is {count}
+    <div className="app">
+      <header>
+        <span>Learn English</span>
+        <button onClick={() => setTheme(theme === 'dark' ? 'light' : 'dark')}>
+          {theme === 'dark' ? 'Light' : 'Dark'}
         </button>
-        <p>
-          Edit <code>src/App.tsx</code> and save to test HMR
-        </p>
-      </div>
-      <p className="read-the-docs">
-        Click on the Vite and React logos to learn more
-      </p>
-    </>
+      </header>
+      <main>{page}</main>
+      <nav className="bottom-nav">
+        <button className={route === 'home' ? 'active' : ''} onClick={() => navigate('home')}>
+          Home
+        </button>
+        <button
+          className={route === 'importer' ? 'active' : ''}
+          onClick={() => navigate('importer')}
+        >
+          Importer
+        </button>
+        <button
+          className={route === 'settings' ? 'active' : ''}
+          onClick={() => navigate('settings')}
+        >
+          Settings
+        </button>
+      </nav>
+    </div>
   )
 }
 

--- a/src/app/home/index.tsx
+++ b/src/app/home/index.tsx
@@ -1,0 +1,8 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>Home</h1>
+      <p>Welcome to Learn English MVP.</p>
+    </div>
+  )
+}

--- a/src/app/importer/index.tsx
+++ b/src/app/importer/index.tsx
@@ -1,0 +1,8 @@
+export default function Importer() {
+  return (
+    <div>
+      <h1>Importer</h1>
+      <p>Paste transcript here (todo).</p>
+    </div>
+  )
+}

--- a/src/app/lesson/index.tsx
+++ b/src/app/lesson/index.tsx
@@ -1,0 +1,12 @@
+interface Props {
+  id: string
+}
+
+export default function Lesson({ id }: Props) {
+  return (
+    <div>
+      <h1>Lesson {id}</h1>
+      <p>Content coming soon.</p>
+    </div>
+  )
+}

--- a/src/app/settings/index.tsx
+++ b/src/app/settings/index.tsx
@@ -1,0 +1,8 @@
+export default function Settings() {
+  return (
+    <div>
+      <h1>Settings</h1>
+      <p>App settings (todo).</p>
+    </div>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -2,32 +2,33 @@
   font-family: system-ui, Avenir, Helvetica, Arial, sans-serif;
   line-height: 1.5;
   font-weight: 400;
-
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-}
 
-a {
-  font-weight: 500;
-  color: #646cff;
-  text-decoration: inherit;
-}
-a:hover {
-  color: #535bf2;
+  --color-bg: #242424;
+  --color-fg: rgba(255, 255, 255, 0.87);
+  --color-link: #646cff;
+  --color-link-hover: #535bf2;
+  --color-border: #333;
 }
 
 body {
   margin: 0;
-  display: flex;
-  place-items: center;
   min-width: 320px;
   min-height: 100vh;
+  background-color: var(--color-bg);
+  color: var(--color-fg);
+}
+
+a {
+  font-weight: 500;
+  color: var(--color-link);
+  text-decoration: inherit;
+}
+a:hover {
+  color: var(--color-link-hover);
 }
 
 h1 {
@@ -47,22 +48,21 @@ button {
   transition: border-color 0.25s;
 }
 button:hover {
-  border-color: #646cff;
+  border-color: var(--color-link);
 }
 button:focus,
 button:focus-visible {
   outline: 4px auto -webkit-focus-ring-color;
 }
 
-@media (prefers-color-scheme: light) {
-  :root {
-    color: #213547;
-    background-color: #ffffff;
-  }
-  a:hover {
-    color: #747bff;
-  }
-  button {
-    background-color: #f9f9f9;
-  }
+body[data-theme='light'] {
+  --color-bg: #ffffff;
+  --color-fg: #213547;
+  --color-link: #646cff;
+  --color-link-hover: #747bff;
+  --color-border: #e5e5e5;
+}
+
+body[data-theme='light'] button {
+  background-color: #f9f9f9;
 }


### PR DESCRIPTION
## Summary
- implement hash-based router with basic pages
- add header, bottom navigation, and theme toggle
- establish light/dark CSS variables for layout shell

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68b409a8f3a4832588159b7a849191ae